### PR TITLE
トップページ商品一覧表示、Seedファイル他

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,3 +95,9 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 gem 'rails-i18n'
 gem 'recaptcha', require: "recaptcha/rails"
+gem 'ancestry'
+gem 'active_hash'
+gem 'faker', :git => 'https://github.com/stympy/faker.git', :branch => 'master'
+
+gem 'carrierwave'
+gem 'kaminari', '~> 0.17.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/stympy/faker.git
+  revision: 8b9302558088c6a1903c7af4f8417a136a96356b
+  branch: master
+  specs:
+    faker (2.7.0)
+      i18n (>= 1.6, < 1.8)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -180,6 +188,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.2.0)
     jwt (2.2.1)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -408,12 +419,14 @@ DEPENDENCIES
   dotenv-rails
   dropzonejs-rails
   factory_bot_rails
+  faker!
   fog-aws
   font-awesome-sass
   haml-rails
   haml_lint
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari (~> 0.17.0)
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/stylesheets/homes/home.scss
+++ b/app/assets/stylesheets/homes/home.scss
@@ -8,12 +8,12 @@
 }
 
 .header-toppage {
-  height: 100px;
+  height: 10rem;
   width: 100%;
-  padding: 8px, 153px;
+  padding: 1rem 15rem;
 
   background-color: rgb(255, 255, 255);
-  box-shadow: rgba(0, 0, 0, 0.18) 0px 2px 4px;
+  box-shadow: rgba(0, 0, 0, 0.18) 0 0.2rem 0.4rem;
   position: relative;
   z-index: 1;
 }
@@ -22,146 +22,144 @@
   display: flex;
   justify-content: center;
 
-  .HeaderTop {
-    height: 40px;
-    width: 75%;
 
-    &__Menu {
-      display: flex;
-      justify-content: space-between;
-      margin-top: 10px;
+  .HeaderTop{
+      height: 5rem;
+      width: 95%;
+      position: relative;
 
-      &__header-logo {
-        height: 45px;
-        width: 180px;
-        padding: 5px;
-        display: block;
-        background-image: url("fmarket_logo_red");
-        background-repeat: no-repeat;
-      }
+      &__Menu{
+        display: flex;
 
-      &__header-search {
-        height: 40px;
-        width: 750px;
-        margin-left: 270px;
+        &__header-logo{
+          height: 4.5rem;
+          width: 18rem;
+          padding: 0.5rem;
+          background-image: url("fmarket_logo_red");
+          background-repeat: no-repeat;
+          position: absolute;
+        }
 
-        background-color: rgb(245, 245, 245);
-        font-size: 16px;
-        height: 40px;
-        line-height: 2.4em;
-        position: absolute;
-        border-width: 1px;
-        border-style: solid;
-        border-color: rgb(204, 204, 204);
-        border-image: initial;
-        border-radius: 4px;
-        outline: none;
-        transition: all 0.3s ease-out 0s;
-      }
+        &__header-search {
+          width: 75rem;
+          margin-left: 27rem;
+          background-color: rgb(245, 245, 245);
+
+          font-size: 1.6rem;
+          height: 4rem;
+          line-height: 2.4em;
+          position: absolute;
+          border-width: 0.1rem;
+          border-style: solid;
+          border-color: rgb(204, 204, 204);
+          border-image: initial;
+          border-radius: 0.4rem;
+          outline: none;
+          transition: all 0.3s ease-out 0s;
+        }
     }
   }
 }
 
-input.search {
+input.search{
   font-family: inherit;
   border: none;
   background-color: #f5f5f5;
-  padding-left: 10px;
+  padding-left: 1rem;
 }
 
 button.search-logo {
   float: right;
-  height: 40px;
-  width: 40px;
+  height: 4rem;
+  width: 4rem;
   border-color: none;
   background-color: #f5f5f5;
 }
 
-img.footer-logo {
-  float: left;
+
+  .HeaderBottom {
+    height: 5rem;
+    width: 75%;
+    display: flex;
+    justify-content: space-between;
+    margin-top: 1rem;
+    bottom: 0;
+    position: absolute;
+
+    &__Left {
+      &__genre_search {
+        display: block;
+        font-size: 1.4rem;
+        font-weight: 600;
+        line-height: 2rem;
+        white-space: nowrap;
+        float: left;
+        padding-right: 2rem;
+        padding-top: 2rem;
+      }
+    }
+
+    &__Right {
+      margin: 0 ;
+      &__Menu-with-sign_in {
+        display: inline-block;
+        align-items: center;
+        font-size: 1.4rem;
+        height: 2rem;
+        padding-right: 3rem;
+        padding-top: 2rem;
+        transform: scale(1);
+        transition: all 0.3s ease-out 0s;
+
+        &__mypage {
+          color: #333;
+          text-decoration: none;
+        }
+      }
+
+      &__Menu-without-sign_in {
+        display: flex;
+        margin-top: 1rem;
+        &__sign_up {
+          background-color: rgb(234, 53, 45);
+          color: rgb(255, 255, 255);
+          display: block;
+          font-size: 1.4rem;
+          border-width: 0.1rem;
+          border-style: solid;
+          border-color: rgb(234, 53, 45);
+          border-image: initial;
+          border-radius: 0.4rem;
+          padding: 0.8rem 1rem;
+        }
+
+        &__sign_in {
+          background-color: rgb(255, 255, 255);
+          color: rgb(0, 149, 238);
+          display: block;
+          font-size: 1.4rem;
+          border-width: 0.1rem;
+          border-style: solid;
+          border-color: rgb(0, 149, 238);
+          border-image: initial;
+          border-radius: 0.4rem;
+          padding: 0.8rem 1rem;
+          margin-left: 1rem;
+        }
+      }
+    }
 }
 
-.HeaderBottom {
-  height: 50px;
-  width: 75%;
-  display: flex;
-  justify-content: space-between;
-  margin-top: 10px;
-  bottom: 0;
 
-  position: absolute;
 
-  &__Left {
-    &__genre_search {
-      display: block;
-      font-size: 14px;
-      font-weight: 600;
-      line-height: 36px;
-      white-space: nowrap;
-      float: left;
-      padding-right: 20px;
-      padding-top: 10px;
-    }
-  }
 
-  &__Right {
-    margin-right: 220px;
-    &__Menu-with-sign_in {
-      display: inline-block;
-      align-items: center;
-      font-size: 14px;
-      height: 32px;
-      padding-right: 30px;
-      padding-top: 20px;
-      transform: scale(1);
-      transition: all 0.3s ease-out 0s;
 
-      &__mypage {
-        color: #333;
-        text-decoration: none;
-      }
-    }
-
-    &__Menu-without-sign_in {
-      display: flex;
-      margin-right: 240px;
-      margin-top: 10px;
-      &__sign_up {
-        background-color: rgb(234, 53, 45);
-        color: rgb(255, 255, 255);
-        display: block;
-        font-size: 14px;
-        border-width: 1px;
-        border-style: solid;
-        border-color: rgb(234, 53, 45);
-        border-image: initial;
-        border-radius: 4px;
-        padding: 8px 10px;
-      }
-
-      &__sign_in {
-        background-color: rgb(255, 255, 255);
-        color: rgb(0, 149, 238);
-        display: block;
-        font-size: 14px;
-        border-width: 1px;
-        border-style: solid;
-        border-color: rgb(0, 149, 238);
-        border-image: initial;
-        border-radius: 4px;
-        padding: 8px 10px;
-        margin-left: 10px;
-      }
-    }
-  }
-}
 
 .Slide-menu {
-  height: 250px;
+  height: 25rem;
   width: 100%;
   background-color: darksalmon;
   text-align: center;
-  // background-image: url("https://image.shutterstock.com/image-vector/pop-art-superhero-young-handsome-260nw-620435939.jpg");
   background-image: url("https://www.haikei-free.com/dataimg/purple0119.png");
 
   background-size: inherit;
@@ -170,191 +168,199 @@ img.footer-logo {
   }
 }
 
-.main-toppage {
-  height: 1200px;
+
+.main-toppage{
   width: 75%;
 
-  .MainMenu {
-    &__FavoriteItems {
-      height: 280px;
-      background-color: #ffbf1f;
-      width: 100%;
-      margin-left: 153px;
-      margin-top: 30px;
+
+.MainMenu{
+
+  &__FavoriteItems{
+    height: 28rem;
+    background-color: #ffbf1f;
+    width: 100%;
+    margin-left: 15.3rem;
+    margin-top: 3rem;
 
       &__Header {
-        height: 50px;
-        display: flex;
+        height: 5rem;
         font-weight: 600;
-        line-height: 1.4em;
+        line-height: 1.4rem;
         margin: 0;
-        padding: 0;
         display: flex;
         justify-content: space-between;
-        padding: 10px;
+        padding: 1rem;
       }
 
-      &__Body {
-        &__Items {
-          &__All {
-            &__List {
-              padding: 30px;
-              float: left;
-
-              &__image {
+      &__Body{
+        &__Items{
+  
+          &__All{
+  
+            &__List{
+              padding: 3rem;
+  
+              &__image{
               }
             }
           }
         }
       }
-    }
+  }
+    
+      
+    
 
-    &__CategoryLists {
-      height: 171px;
+  &__CategoryLists {
+      height: 17.1rem;
       width: 100%;
       background-color: rgb(255, 255, 255);
-      margin-left: 153px;
+      margin-left: 15.3rem;
+
 
       &__List {
         &__All {
-          height: 40px;
-          width: 100%;
-          align-items: center;
-
-          &__list {
-            display: block;
-            font-size: 14px;
-            height: 32px;
-            width: 180px;
-
-            padding: 10px;
-            margin: 10px;
-
-            float: left;
-            margin-top: 20px;
-            margin-left: 50px;
-
-            text-align: center;
-            background-color: #dddddd;
-            border-radius: 20px;
-          }
-        }
-      }
-    }
-
-    &__CategoryItems {
-      height: 400px;
-      background-color: #000000;
-      width: 100%;
-      margin-left: 153px;
-
-      &__Header {
-        display: flex;
-        font-weight: 600;
-        line-height: 1.4em;
-        margin: 0;
-        padding: 0;
-
-        height: 50px;
-        justify-content: space-between;
-        padding: 15px;
-      }
-
-      &__Body {
-        &__Items {
-          &__All {
-            &__List {
-              height: 300px;
-              width: 250px;
-              padding: 10px;
-              float: left;
-
-              &__image {
-                width: 200px;
-              }
-            }
-          }
-        }
-      }
-
-      h3.category-item-title {
-        font-size: 24px;
-        color: #dddddd;
-      }
-
-      figure.body-item {
-      }
-    }
-    &__BrandLists {
-      height: 171px;
-      width: 100%;
-      background-color: rgb(255, 255, 255);
-      margin-left: 153px;
-
-      &__List {
-        &__All {
-          height: 40px;
-          width: 100%;
-          float: left;
+          width: 75%;
+          margin-left: 13.5rem;
 
           &__list {
             display: inline-block;
-            font-size: 14px;
-            height: 32px;
+            font-size: 1.4rem;
+            height: 3.2rem;
 
-            padding: 10px;
-
-            margin-top: 20px;
-            margin-left: 120px;
+            padding: 1rem;
+            margin: 4rem 2rem 0 2rem;
 
             background-color: #dddddd;
-            border-radius: 20px;
+            border-radius: 2rem;
+
           }
         }
       }
     }
+  
 
-    &__BrandItems {
-      height: 400px;
-      background-color: #000000;
-      width: 100%;
-      margin-left: 153px;
-      margin-bottom: 50px;
+  &__CategoryItems{
+    height: 40rem;
+    background-color: #000000;
+    width: 100%;
+    margin-left: 15.3rem;
 
-      &__Header {
-        display: flex;
-        font-weight: 600;
-        line-height: 1.4em;
-        margin: 0;
-        padding: 0;
+    &__Header{
+      display: flex;
+      font-weight: 600;
+      line-height: 1.4rem;
+      margin: 0;
 
-        height: 50px;
-        justify-content: space-between;
-        padding: 15px;
+      height: 5rem;
+      justify-content: space-between;
+      padding: 15px;
+
+
+    }
+
+    &__Body{
+    
+      &__Items{
+        
+        &__All{
+          height:30rem;
+          width: 100%;
+          
+
+          &__List{
+            padding: 1rem, 1.6rem, 0, 1.6rem;
+            display: flex;
+            
+  
+          }
+        }
       }
+    }
+  
 
-      &__Body {
-        &__Items {
-          &__All {
-            &__List {
-              height: 300px;
-              width: 250px;
-              padding: 10px;
-              float: left;
 
-              &__image {
-                width: 200px;
-              }
+h3.category-item-title{
+  font-size: 2.4rem;
+  color: #dddddd;
+}
+
+
+  }
+      
+    
+    &__BrandLists {
+      height: 17.1rem;
+      width: 100%;
+      background-color: rgb(255, 255, 255);
+      margin-left: 15.3rem;
+
+      &__List {
+        &__All {
+          width: 75%;
+          margin-left: 11.5rem;
+  
+          &__list{
+          
+            display: inline-block;
+            font-size: 1.4rem;
+            height: 3.2rem;
+
+            padding: 1rem;
+            margin: 4rem 5rem 0 5rem;
+
+            background-color: #dddddd;
+            border-radius: 2rem;
+          }
+        }
+      }
+  }
+  
+
+  &__BrandItems{
+    height: 40rem;
+    background-color: #000000;
+    width: 100%;
+    margin-left: 15.3rem;
+    margin-bottom: 5rem;
+
+    &__Header{
+      display: flex;
+      font-weight: 600;
+      line-height: 1.4rem;
+      margin: 0;
+
+      height: 5rem;
+      justify-content: space-between;
+      padding: 1.5rem;
+
+    }
+
+    &__Body{
+
+      &__Items{
+
+      
+        &__All{
+          height: 30rem;
+          width: 100%;
+
+          &__List{
+            padding: 1rem 1.6rem 0 1.6rem;
+            display: flex;
+
             }
           }
         }
       }
     }
   }
+  
 }
 
+
 h3.brand-item-title {
-  font-size: 24px;
+  font-size: 2.4rem;
   color: #dddddd;
 }
 
@@ -363,60 +369,47 @@ p.show-detail {
   color: #dddddd;
 }
 
-figcaption {
-  display: block;
-  height: 50px;
-  width: 200px;
-  display: flex;
-  justify-content: center;
-  z-index: 0;
-  background-color: white;
-  border-style: ridge;
-}
 
-span.body-item-pricetag {
-  align-items: center;
-  background: rgba(0, 0, 0, 0.4);
-  border-radius: 0 14px 14px 0;
-  bottom: 8px;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-  color: #fff;
-  display: inline-flex;
-  font-size: 17px;
-  height: 32px;
-  height: 28px;
-  letter-spacing: 0.02em;
-  margin: 0;
-  padding: 0 12px;
+figcaption{
+  height: 5rem;
+  width: 20rem;
+  margin: 0.1rem 1rem 1rem 1rem;
   position: absolute;
-  z-index: 2;
+  background-color: grey;
+  color: #dddddd;
+  text-align: center;
+  line-height: initial;
 }
 
-img.body-item-image {
-  display: block;
-  height: 230px;
-  width: 200px;
+
+.body-item-image{
+  display: flex;
+  height: 23rem;
+  width: 20rem;
   border-style: groove;
-  position: relative;
+  background-size: cover;
+  margin: 1rem;
+
 }
 
-img.favorite-item-image {
+.favorite-item-image {
   display: block;
-  height: 150px;
-  width: 180px;
+  height: 15rem;
+  width: 18rem;
   border-style: outset;
-  position: relative;
+  float: left;
+  background-size: cover;
+  margin: 1rem;
 }
 
 h2.category-title {
   text-align: center;
   display: block;
-  padding-top: 20px;
+  padding-top: 2rem;
 }
 
-a.category-list {
-  display: inline-block;
+
+a.category-list{
   display: flex;
   justify-content: center;
 }
@@ -428,16 +421,17 @@ ul.FooterMenu__list_wrapper {
 }
 
 li.FooterMenu__list__small {
-  text-align: left;
   line-height: 1.4em;
-  margin: 10px 0 0 0;
+  margin: 1rem 0 0 0;
   opacity: 0.7;
 }
 
 .aside-toppage {
-  height: 180px;
+  height: 18rem;
+  width: 100%;
   background-size: inherit;
-
+  background-color: darkorange;
+  
   display: flex;
   justify-content: center;
 
@@ -453,28 +447,25 @@ li.FooterMenu__list__small {
 
 p.aside-text1 {
   color: rgb(255, 255, 255);
-  margin-top: 30px;
-  font-size: 24px;
-  text-shadow: 1px 1px 0 gray, -1px 1px 0 gray, 1px -1px 0 gray,
-    -1px -1px 0 gray;
+  margin-top: 3rem;
+  font-size: 2.4rem;
+  text-shadow: 0.1rem 0.1rem 0 gray, -0.1rem 0.1rem 0 gray, 0.1rem -0.1rem 0 gray,
+    -0.1rem -0.1rem 0 gray;
 }
 
 p.aside-text2 {
   color: rgb(255, 255, 255);
-  font-size: 24px;
-  text-shadow: 1px 1px 0 gray, -1px 1px 0 gray, 1px -1px 0 gray,
-    -1px -1px 0 gray;
+  font-size: 2.4rem;
+  text-shadow: 0.1rem 0.1rem 0 gray, -0.1rem 0.1rem 0 gray, 0.1rem -0.1rem 0 gray,
+    -0.1rem -0.1rem 0 gray;
 }
 
 img.aside-image1 {
   display: block;
-  height: 180px;
-  width: 180px;
-  padding-left: 20px;
+  padding-left: 2rem;
 }
 
-.footer-toppage {
-  height: 289px;
+.footer-toppage{
   width: 100%;
   background-color: #ff006f;
   color: #ffffff;
@@ -486,84 +477,97 @@ img.aside-image1 {
   justify-content: center;
 }
 
-.FooterMenu {
-  height: 296px;
-  width: 75%;
-  float: left;
+.FooterMenu{
+    height: 25rem;
+    width: 75%;
+    float: left;
 
-  &__list {
-    display: inline-block;
-    width: 200px;
-    vertical-align: top;
-    margin: 36px;
-    padding-left: 0;
 
-    &__title {
-      font-size: 16px;
+    &__list{
+      display: inline-block;
+      width: 20rem;
+      vertical-align: top;
+      margin: 3.2rem 3.2rem 0 0;
+      padding-left: 0;
+    
+      &__title{
+        font-size: 1.6rem;
+      }
+      
+      &__small{
+        font-size: 1.2rem;
+        margin-left: 1.6rem;
+        font: inherit;
+      }
     }
-
-    &__small {
-      font-size: 12px;
-      font: inherit;
-    }
-  }
 }
+
+h2.FooterMenu__list__title{
+  text-align: left;
+}
+
 
 .FooterBottom {
   width: 75%;
-  height: 33px;
+  height: 3.3rem;
   position: absolute;
-  bottom: 20px;
+  bottom: 2rem;
+
+  &__footer-logo{
+    height: 3.3rem;
+    width: 12rem;
+    padding: 2.5rem 0.5rem 0.5rem 0.5rem;
+    background-image: url("fmarket_logo_white");
+    background-repeat: no-repeat;
+  }
+  
+  &__footer-text{
+    text-align: center;
+    width: 76rem;
+    height: 1.2rem;
+    font-size: 1.2rem;
+    padding-left: 28rem;
+  }
+  
+
 }
 
-.footer-logo {
-  height: 33px;
-  width: 124px;
-  padding: 25px 5px 5px 5px;
-  display: block;
-  background-image: url("fmarket_logo_white");
-  background-repeat: no-repeat;
-}
 
-span.footer-text {
-  text-align: center;
-  width: 765px;
-  height: 12px;
-  font-size: 12px;
-  padding-left: 280px;
-}
 
-.PostItems {
-  width: 200px;
-  height: 200px;
-  padding: 20px;
+.PostItems{
+  width: 20rem;
+  height: 20rem;
+  padding: 2rem;
   position: fixed;
-  bottom: 5px;
+  bottom: 0.5rem;
   right: 0;
   display: inline-block;
   display: flex;
   justify-content: center;
   z-index: 100;
 
-  &__Button {
-    padding-top: 15px;
+
+  &__Button{
+    padding-top: 1.5rem;
     text-align: center;
-    height: 140px;
-    width: 140px;
+    height: 14rem;
+    width: 14rem;
     background-color: rgb(234, 53, 45);
     border-radius: 50%;
     color: white;
-    font-size: 22px;
-  }
+    font-size: 2rem;
+   }
 
-  &__Icon {
-    display: block;
-    height: 50px;
-    width: 50px;
-    color: white;
-    display: flex;
-    justify-content: center;
-    margin-top: 7px;
-    margin-left: 45px;
-  }
-}
+
+    &__Icon{
+        height: 5rem;
+        width: 5rem;
+        color: white;
+        display: flex;
+        justify-content: center;
+        margin-top: 0.7rem;
+        margin-left: 4.5rem;
+    
+    }
+
+ }

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,3 +1,24 @@
 class HomesController < ApplicationController
-  def index; end
+  def index
+    @like_rankings = Image.find(Like.group(:item_id).order('count(item_id) desc').limit(4).pluck(:item_id))
+
+    @category_rankings = Category.find(Item.group(:category_id).order('count(category_id) desc').limit(4).pluck(:category_id))
+
+    @categorytitle = Category.find(Item.group(:category_id).order('count(category_id) desc').limit(1).pluck(:category_id))
+
+    @categoryitems = Item.where(category_id: @categorytitle[0].id)
+
+    @brand_rankings = Brand.find(Item.group(:brand_id).order('count(brand_id) desc').limit(4).pluck(:brand_id))
+
+    @brandtitle = Brand.find(Item.group(:brand_id).order('count(brand_id) desc').limit(1).pluck(:brand_id))
+
+    @branditems = Item.where(brand_id: @brandtitle[0].id)
+  end
+
+  private
+  def item_params
+    params.permit(:email, :password)
+  end
+
+
 end

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -1,0 +1,47 @@
+class ImagesUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/homes/_footer.html.haml
+++ b/app/views/homes/_footer.html.haml
@@ -24,8 +24,8 @@
                         XXXXXX
 
         .FooterBottom
-            .footer-logo
+            .FooterBottom__footer-logo
             
-                %span.footer-text 
-                    © 2019 Fmarket
+            .FooterBottom__footer-text 
+                © 2019 Fmarket
 

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -18,20 +18,8 @@
                         .MainMenu__FavoriteItems__Body__Items__All
                             .MainMenu__FavoriteItems__Body__Items__All__List
                                 .MainMenu__FavoriteItems__Body__Items__All__List__image
-                                    %img.favorite-item-image{alt:"", src: "https://static.mercdn.net/item/detail/orig/photos/m68735417310_1.jpg?1571708042"}/
-                                    -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                            .MainMenu__FavoriteItems__Body__Items__All__List
-                                .MainMenu__FavoriteItems__Body__Items__All__List__image
-                                    %img.favorite-item-image{alt:"", src: "https://static.mercdn.net/item/detail/orig/photos/m68735417310_1.jpg?1571708042"}/
-                                    -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                            .MainMenu__FavoriteItems__Body__Items__All__List
-                                .MainMenu__FavoriteItems__Body__Items__All__List__image
-                                    %img.favorite-item-image{alt:"", src: "https://static.mercdn.net/item/detail/orig/photos/m68735417310_1.jpg?1571708042"}/
-                                    -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                            .MainMenu__FavoriteItems__Body__Items__All__List
-                                .MainMenu__FavoriteItems__Body__Items__All__List__image
-                                    %img.favorite-item-image{alt:"", src: "https://static.mercdn.net/item/detail/orig/photos/m68735417310_1.jpg?1571708042"}/
-                                    -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
+                                    - @like_rankings.each do |image|
+                                        = image_tag image.image , height: '150', width: '180', class:'favorite-item-image'
 
 
 
@@ -39,100 +27,59 @@
                 %h2.category-title 人気のカテゴリー
                 .MainMenu__CategoryLists__List
                     .MainMenu__CategoryLists__List__All
-                        .MainMenu__CategoryLists__List__All__list
-                            %a.category-list 福岡
-                        .MainMenu__CategoryLists__List__All__list
-                            %a.category-list 明太子
-                        .MainMenu__CategoryLists__List__All__list
-                            %a.category-list めんたいパーク
-                        .MainMenu__CategoryLists__List__All__list
-                            %a.category-list 赤い皮に包まれた魚卵
+                        - @category_rankings.each do |category|
+                            .MainMenu__CategoryLists__List__All__list
+                                %p.category-list 
+                                    = category.name
+
 
             .MainMenu__CategoryItems
                 .MainMenu__CategoryItems__Header
-                    %h3.category-item-title MENTAI 新着アイテム
+                    %h3.category-item-title 
+                        - @categorytitle.each do |category|
+                            = category.name
+                        %span 新着アイテム
                     %p.show-detail もっと見る >
                 .MainMenu__CategoryItems__Body
                     .MainMenu__CategoryItems__Body__Items
                         .MainMenu__CategoryItems__Body__Items__All
                             .MainMenu__CategoryItems__Body__Items__All__List
-                                %div{ style: "visibility: visible; transition: all 0.5s ease 0s; opacity: 1;"}
-                                    %figure.body-item
-                                        .MainMenu__CategoryItems__Body__Items__All__List__image
-                                            -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                                            %img.body-item-image{alt: "", src: "https://static.mercdn.net/item/detail/orig/photos/m51605700246_1.jpg?1573572058"}/
-                                        %figcaption
-                                            %span セール13000円→12000円　めんたいマヨネーズ
+                                - @categoryitems.each do |item|
+                                    %figure
+                                        = image_tag item.images.first.image , height: '230', width: '200', class:'body-item-image'
+                                        %figcaption 
+                                            = item.name
+                                    
 
-                            .MainMenu__CategoryItems__Body__Items__All__List
-                                %div{:style => "visibility: visible; transition: all 0.5s ease 0s; opacity: 1;"}
-                                    %figure.body-item
-                                        .MainMenu__CategoryItems__Body__Items__All__List__image
-                                            -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                                            %img.body-item-image{alt: "", src: "https://static.mercdn.net/item/detail/orig/photos/m51605700246_1.jpg?1573572058"}/
-                                        %figcaption
-                                            %span セール13000円→12000円　めんたいマヨネーズ
-
-                            .MainMenu__CategoryItems__Body__Items__All__List
-                                %div{:style => "visibility: visible; transition: all 0.5s ease 0s; opacity: 1;"}
-                                    %figure.body-item
-                                        .MainMenu__CategoryItems__Body__Items__All__List__image
-                                            -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                                            %img.body-item-image{alt: "", src: "https://static.mercdn.net/item/detail/orig/photos/m51605700246_1.jpg?1573572058"}/
-                                        %figcaption
-                                            %span セール13000円→12000円　めんたいマヨネーズ
-
-
-
+                            
+                                        
 
             .MainMenu__BrandLists
                 %h2.category-title 人気のブランド
                 .MainMenu__BrandLists__List
                     .MainMenu__BrandLists__List__All
-                        .MainMenu__BrandLists__List__All__list
-                            %a.brand-list ドイツ
-                        .MainMenu__BrandLists__List__All__list
-                            %a.brand-list スイス
-                        .MainMenu__BrandLists__List__All__list
-                            %a.brand-list ジョージア
-                        .MainMenu__BrandLists__List__All__list
-                            %a.brand-list オーロラ
+                        - @brand_rankings.each do |brand|
+                            .MainMenu__BrandLists__List__All__list
+                                %p.brand-list 
+                                    = brand.name
+
 
             .MainMenu__BrandItems
                 .MainMenu__BrandItems__Header
-                    %h3.brand-item-title 魚卵ブランド 新着アイテム
+                    %h3.brand-item-title 
+                        - @brandtitle.each do |brand|
+                            = brand.name  
+                        %span 新着アイテム
                     %p.show-detail もっと見る >
                 .MainMenu__BrandItems__Body
                     .MainMenu__BrandItems__Body__Items
                         .MainMenu__BrandItems__Body__Items__All
                             .MainMenu__BrandItems__Body__Items__All__List
-                                %div{style: "visibility: visible; transition: all 0.5s ease 0s; opacity: 1;"}
-                                    %figure.body-item
-                                        .MainMenu__BrandItems__Body__Items__All__List__image
-                                            -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                                            %img.body-item-image{alt: "Thumbnail of \"セール13000円→12000円　Douxmiere キュービックネックレス\"", src: "https://static.mercdn.net/thumb/photos/m68548725798_1.jpg?1562335238"}/
+                                - @branditems.each do |item|
+                                    %figure
+                                        = image_tag item.images.first.image , height: '230', width: '200', class:'body-item-image'
                                         %figcaption
-                                            %span セール13000円→12000円　めんたいマヨネーズ
-
-                            .MainMenu__BrandItems__Body__Items__All__List
-                                %div{:style => "visibility: visible; transition: all 0.5s ease 0s; opacity: 1;"}
-                                    %figure.body-item
-                                        .MainMenu__BrandItems__Body__Items__All__List__image
-                                            -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                                            %img.body-item-image{alt: "Thumbnail of \"セール13000円→12000円　Douxmiere キュービックネックレス\"", src: "https://static.mercdn.net/thumb/photos/m68548725798_1.jpg?1562335238"}/
-                                        %figcaption
-                                            %span セール13000円→12000円　めんたいマヨネーズ
-
-                            .MainMenu__BrandItems__Body__Items__All__List
-                                %div{:style => "visibility: visible; transition: all 0.5s ease 0s; opacity: 1;"}
-                                    %figure.body-item
-                                        .MainMenu__BrandItems__Body__Items__All__List__image
-                                            -# %span.body-item-pricetag{"aria-label" => "Price"} ¥12,000
-                                            %img.body-item-image{alt: "Thumbnail of \"セール13000円→12000円　Douxmiere キュービックネックレス\"", src: "https://static.mercdn.net/thumb/photos/m68548725798_1.jpg?1562335238"}/
-                                        %figcaption
-                                            %span セール13000円→12000円　めんたいマヨネーズ
-
-
+                                            = item.name
 
 
     %aside.aside-toppage
@@ -140,11 +87,13 @@
             .Aside__Text__Lists
                 %p.aside-text1 Fmarket  わくわくフリマアプリ
                 %p.aside-text2 今すぐ出品してみよう！
-            %img.aside-app{alt: "", src:"https://web-jp-assets.mercdn.net/_next/static/images/app-store-a5c17948c6fd6d5b60b13d421cd60b35.svg"}/
-            %img.aside-app{alt: "", src: "https://web-jp-assets.mercdn.net/_next/static/images/google-play-495575abb895b405aa6336b2a4304958.svg"}/
+            = image_tag "https://web-jp-assets.mercdn.net/_next/static/images/app-store-a5c17948c6fd6d5b60b13d421cd60b35.svg", alt: "", class: "aside-app"
+
+            = image_tag "https://web-jp-assets.mercdn.net/_next/static/images/google-play-495575abb895b405aa6336b2a4304958.svg", alt: "", class: "aside-app"
+
 
         .Aside__Image
-            %img.aside-image1{alt: "", src: "https://web-jp-assets.mercdn.net/_next/static/images/download_app_pc-a4418175e8be071827ac88d073f40e4a.png"}/
+            = image_tag "https://i.pinimg.com/originals/67/0c/e8/670ce89d7ce9d88121c0bf33a1d478e4.png", alt: "", class: "aside-image1", height: '200', width: '270'
 
     = render 'footer'
     = render 'postitem'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,4 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,5 @@ Rails.application.config.assets.precompile += %w[*.svg]
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+Rails.application.config.assets.precompile += %w( home.scss )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,215 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+
+# User
+User.create!(
+  [
+    {
+      email: 'jonny@gmail.com',
+      password: 'jonny1234',
+      nickname: '波乗りJonny',
+      lastname: 'Naminori', 
+      firstname: 'Jonny',
+      lastname_kana: 'ナミノリ',
+      firstname_kana: 'ジョニー',
+      birthday_year: '2000',
+      birthday_month: '1', 
+      birthday_day: '1',
+      phonenumber: '09012345678',
+    },
+    {
+      email: 'samurai@gmail.com',
+      password: 'samurai2345',
+      nickname: 'さすらいの侍', 
+      lastname: 'Sasurai',
+      firstname: 'Samurai',
+      lastname_kana: 'サスライ',
+      firstname_kana: 'サムライ',
+      birthday_year: '1992', 
+      birthday_month: '3',
+      birthday_day: '3',
+      phonenumber: '08033333333',
+    },
+    {
+      email: 'omochi@gmail.com',
+      password: 'omochi3456',
+      nickname: 'お餅にはおしるこ',
+      lastname: 'oshiruko', 
+      firstname: 'omochi', 
+      lastname_kana: 'オシルコ', 
+      firstname_kana: 'オモチ',
+      birthday_year: '1993', 
+      birthday_month: '5',
+      birthday_day: '18',
+      phonenumber: '08055555555',
+    },
+  ]
+)
+
+
+
+
+# # ブランド レディース
+Brand.create!(
+  [
+    {
+      name: 'グッチ',
+    },
+    {
+      name: 'シャネル',
+    },
+  ]
+)
+
+# # ブランド メンズ
+Brand.create!(
+  [
+    {
+      name: 'ナイキ',
+    },
+    {
+      name: 'プーマ',
+    },
+  ]
+)
+
+
+# # ブランド ベビー・キッズ
+Brand.create!(
+  [
+    {
+      name: '西松屋',
+    },
+  ]
+)
+
+
+# # ブランド インテリア・住まい・小物
+Brand.create!(
+  [
+    {
+      name: 'イケア',
+    },
+    {
+      name: '無印用品',
+    },
+  ]
+)
+
+# # 本・音楽・ゲーム
+Brand.create!(
+  [
+    {
+      name: 'ニンテンドー',
+    },
+    {
+      name: 'カドカワ文庫',
+    },
+
+  ]
+)
+
+# # おもちゃ・ホビー・グッズ
+Brand.create!(
+  [
+    {
+      name: 'タカラトミー',
+    },
+  ]
+)
+
+
+# # ブランド コスメ・香水・美容
+Brand.create!(
+  [
+    {
+      name: 'クロエ',
+    },
+    {
+      name: 'Dior',
+    },
+  ]
+)
+
+
+# # ブランド 家電・スマホ・カメラ
+Brand.create!(
+  [
+    {
+      name: 'Apple',
+    },
+    {
+      name: 'パナソニック',
+    },
+  ]
+)
+
+# # ブランド スポーツ・レジャー
+Brand.create!(
+  [
+    {
+      name: 'アディダス',
+    },
+    {
+      name: 'バタフライ',
+    },
+  ]
+)
+
+
+
+# # ハンドメイド
+Brand.create!(
+  [
+    {
+      name: 'ワクワクハンド',
+    },
+  ]
+)
+
+
+# # チケット
+Brand.create!(
+  [
+    {
+      name: '大黒屋',
+    },
+    {
+      name: 'ワクワクチケット',
+    },
+  ]
+)
+
+
+# # 自動車・オートバイ
+Brand.create!(
+  [
+    {
+      name: 'スズキ',
+    },
+    {
+      name: 'スペースワールド',
+    },
+  ]
+)
+
+
+# # その他
+Brand.create!(
+  [
+    {
+      name: 'ディズニー',
+    },
+    {
+      name: 'ネスレ',
+    },
+  ]
+)
+
+
+
+# 親カテゴリー
 lady = Category.create(name: "レディース")
 man = Category.create(name: "メンズ")
 baby = Category.create(name: "ベビー・キッズ")
@@ -170,7 +379,744 @@ other_food = other.children.create(name: "食品")
 other_drink = other.children.create(name: "飲料/酒")
 other_other = other.children.create(name: "その他")
 # その他の孫カテゴリ
-other_matome.children.create([{ name: "ペットフード" }, { name: "犬用品" }, { name: "猫用品" }, { name: "魚用品/水草" }, { name: "小動物用品" }, { name: "爬虫類/両生類用品" }, { name: "かご/おり" }, { name: "鳥用品" }, { name: "虫類用品" }, { name: "その他" }])
-other_food.children.create([{ name: "菓子" }, { name: "米" }, { name: "野菜" }, { name: "果物" }, { name: "調味料" }, { name: "魚介類(加工食品)" }, { name: "肉類(加工食品)" }, { name: "その他 加工食品" }, { name: "その他" }])
-other_drink.children.create([{ name: "コーヒー" }, { name: "ソフトドリンク" }, { name: "ミネラルウォーター" }, { name: "茶" }, { name: "ウイスキー" }, { name: "ワイン" }, { name: "ブランデー" }, { name: "焼酎" }, { name: "日本酒" }, { name: "ビール、発泡酒" }, { name: "その他" }])
-other_other.children.create([{ name: "オフィス用品一般" }, { name: "オフィス家具" }, { name: "店舗用品" }, { name: "OA機器" }, { name: "ラッピング/包装" }, { name: "その他" }])
+other_matome.children.create([{name: "ペットフード"}, {name: "犬用品"}, {name: "猫用品"}, {name: "魚用品/水草"}, {name: "小動物用品"}, {name: "爬虫類/両生類用品"}, {name: "かご/おり"}, {name: "鳥用品"}, {name: "虫類用品"}, {name: "その他"}])
+other_food.children.create([{name: "菓子"}, {name: "米"}, {name: "野菜"}, {name: "果物"}, {name: "調味料"}, {name: "魚介類(加工食品)"}, {name: "肉類(加工食品)"}, {name: "その他 加工食品"}, {name: "その他"}])
+other_drink.children.create([{name: "コーヒー"}, {name: "ソフトドリンク"}, {name: "ミネラルウォーター"}, {name: "茶"}, {name: "ウイスキー"}, {name: "ワイン"}, {name: "ブランデー"}, {name: "焼酎"}, {name: "日本酒"}, {name: "ビール、発泡酒"}, {name: "その他"}])
+other_other.children.create([{name: "オフィス用品一般"}, {name: "オフィス家具"}, {name: "店舗用品"}, {name: "OA機器"}, {name: "ラッピング/包装"}, {name: "その他"}])
+
+
+# アイテム レディース
+Item.create!(
+  [
+    {
+      name: 'シャネルセール品３点', 
+      price: '15000', 
+      usage_status: '新品', 
+      description: 'お買い得！シャネルのおしゃれアイテム３点セット',
+      selling_status: '出品中', 
+      delivery_fee: '100', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '埼玉県',
+      shipping_date: '20191109',
+      user_id: '1', 
+      brand_id: '2', 
+      category_id: '1', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'カビゴン着ぐるみ', 
+      price: '3500', 
+      usage_status: '新品', 
+      description: 'カビゴンを着て美味しいものを食べに行こう',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '東京都',
+      shipping_date: '20191110',
+      user_id: '1', 
+      brand_id: '7', 
+      category_id: '1', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'グッチTシャツ', 
+      price: '3500', 
+      usage_status: '新品', 
+      description: 'ヤングでトレンディなTシャツ',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '徳島県',
+      shipping_date: '20191224',
+      user_id: '1', 
+      brand_id: '1', 
+      category_id: '1', 
+      payment_status: '支払済'
+    },
+
+
+
+  ]
+)
+
+# アイテム メンズ
+Item.create!(
+  [
+    {
+      name: '黄金に輝く胸筋', 
+      price: '50000', 
+      usage_status: '新品', 
+      description: 'まるで太陽のように輝く筋肉。今だけセール中',
+      selling_status: '出品中', 
+      delivery_fee: '2000', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '東京都',
+      shipping_date: '20191108',
+      user_id: '2', 
+      brand_id: '3', 
+      category_id: '2', 
+      payment_status: '支払済'
+
+    },
+    {
+      name: 'ブラウンニット', 
+      price: '12000', 
+      usage_status: '新品', 
+      description: 'この季節に一押しのニット。彼女とのデートでも好印象',
+      selling_status: '出品中', 
+      delivery_fee: '2000', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '東京都',
+      shipping_date: '20191108',
+      user_id: '2', 
+      brand_id: '4', 
+      category_id: '2', 
+      payment_status: '支払済'
+
+    },
+    {
+      name: 'イケてるトレンチコート', 
+      price: '15000', 
+      usage_status: '新品', 
+      description: 'ビジネスもクールにこなせる旬のトレンチコート',
+      selling_status: '出品中', 
+      delivery_fee: '2000', 
+      delivery_way: '普通郵便',
+      delivery_area: '島根県',
+      shipping_date: '20191111',
+      user_id: '3', 
+      brand_id: '6', 
+      category_id: '2', 
+      payment_status: '支払済'
+
+    },
+
+
+  ]
+)
+
+# アイテム キッズ・ベイビー
+Item.create!(
+  [
+    {
+      name: 'ボスベイビーと遊べる券', 
+      price: '2000', 
+      usage_status: '新品', 
+      description: 'あのボスベイビーがあなたの元にやってくる',
+      selling_status: '取引中', 
+      delivery_fee: '10', 
+      delivery_way: '普通郵便',
+      delivery_area: '東京都',
+      shipping_date: '20190819',
+      user_id: '3', 
+      brand_id: '19', 
+      category_id: '3', 
+      payment_status: '未払い'
+
+    },
+    {
+      name: 'ギフトにもGoodよだれかけ', 
+      price: '3000', 
+      usage_status: '新品', 
+      description: 'おしゃれなよだれかけ',
+      selling_status: '取引中', 
+      delivery_fee: '10', 
+      delivery_way: '普通郵便',
+      delivery_area: '東京都',
+      shipping_date: '20190819',
+      user_id: '3', 
+      brand_id: '5', 
+      category_id: '3', 
+      payment_status: '未払い'
+
+    },
+
+  ]
+)
+
+
+# インテリア・住まい・小物
+Item.create!(
+  [
+    {
+      name: '流れるアンモナイト型シンク', 
+      price: '12000', 
+      usage_status: '中古', 
+      description: '旧石器時代のアンモナイトの造形をモデルとしたデザインシンク',
+      selling_status: '取引中', 
+      delivery_fee: '10', 
+      delivery_way: '普通郵便',
+      delivery_area: '鹿児島県',
+      shipping_date: '20190818',
+      user_id: '1', 
+      brand_id: '20', 
+      category_id: '4', 
+      payment_status: '支払済'
+
+    },
+    {
+      name: 'アップルメモパッド', 
+      price: '1200', 
+      usage_status: '新品', 
+      description: 'かのリンゴ型メモ',
+      selling_status: '取引中', 
+      delivery_fee: '10', 
+      delivery_way: '普通郵便',
+      delivery_area: '鹿児島県',
+      shipping_date: '20190818',
+      user_id: '1', 
+      brand_id: '13', 
+      category_id: '4', 
+      payment_status: '支払済'
+
+    },
+
+
+
+  ]
+)
+  
+
+# 本・音楽・ゲーム
+Item.create!(
+  [
+    {
+      name: '安心引きこもりライフ', 
+      price: '800', 
+      usage_status: '中古', 
+      description: '現代人必読の一冊。家にこもってこそ見える人生もある',
+      selling_status: '出品中', 
+      delivery_fee: '10', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '沖縄県',
+      shipping_date: '20190818',
+      user_id: '2', 
+      brand_id: '9', 
+      category_id: '5', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'マッチョでポン！', 
+      price: '1500', 
+      usage_status: '中古', 
+      description: '筋肉を育てよう！筋肉育成ゲーム',
+      selling_status: '出品中', 
+      delivery_fee: '100', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '長崎県',
+      shipping_date: '20190818',
+      user_id: '2', 
+      brand_id: '10', 
+      category_id: '5', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'ゲームキューブカセットのみ', 
+      price: '500', 
+      usage_status: '中古', 
+      description: '懐かしのゲームキューブ',
+      selling_status: '出品中', 
+      delivery_fee: '100', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '長崎県',
+      shipping_date: '20190818',
+      user_id: '2', 
+      brand_id: '15', 
+      category_id: '5', 
+      payment_status: '支払済'
+    },
+
+
+  ]
+)
+  
+
+# おもちゃ・ホビー・グッズ
+Item.create!(
+  [
+    {
+      name: 'ゲロゲロな卵の黄身', 
+      price: '1300', 
+      usage_status: '新品', 
+      description: 'あなたのストレスも黄身と一緒に流しちゃいます',
+      selling_status: '出品中', 
+      delivery_fee: '300', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '北海道',
+      shipping_date: '20191010',
+      user_id: '3', 
+      brand_id: '10', 
+      category_id: '6', 
+      payment_status: '支払済'
+    },
+  ]
+)
+  
+# コスメ・香水・美容
+Item.create!(
+  [
+    {
+      name: 'フリーザのような美肌に！ドラゴンボールフェイスパック', 
+      price: '300', 
+      usage_status: '中古', 
+      description: 'これであなたもフリーザのような美肌になれる',
+      selling_status: '出品中', 
+      delivery_fee: '50', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '北海道',
+      shipping_date: '20191105',
+      user_id: '2', 
+      brand_id: '15', 
+      category_id: '7', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'クロエ香水', 
+      price: '5000', 
+      usage_status: '新規', 
+      description: 'フレンチで大人な香りを',
+      selling_status: '出品中', 
+      delivery_fee: '50', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '北海道',
+      shipping_date: '20191105',
+      user_id: '2', 
+      brand_id: '11', 
+      category_id: '7', 
+      payment_status: '支払済'
+    },
+
+
+
+  ]
+)
+  
+# 家電・スマホ・カメラ
+Item.create!(
+  [
+    {
+      name: 'ピザ生成機', 
+      price: '5000', 
+      usage_status: '新品', 
+      description: '窯焼きピザ顔負けのふっくらピザが焼けます',
+      selling_status: '売却済み', 
+      delivery_fee: '300', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '大阪府',
+      shipping_date: '20191009',
+      user_id: '2', 
+      brand_id: '14', 
+      category_id: '8', 
+      payment_status: '支払済'
+    },
+  ]
+)
+
+# スポーツ・レジャー
+Item.create!(
+  [
+    {
+      name: 'おしるこプロテイン', 
+      price: '1050', 
+      usage_status: '新品', 
+      description: 'お餅は炭水化物なので摂取NG。甘いおしるこ風味のプロテインで筋肉ムキムキになろう',
+      selling_status: '出品停止', 
+      delivery_fee: '300', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '大阪府',
+      shipping_date: '20191009',
+      user_id: '3', 
+      brand_id: '23', 
+      category_id: '9', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'バタフライ卓球ラケット', 
+      price: '2050', 
+      usage_status: '新品', 
+      description: '老舗卓球メーカーのラケット',
+      selling_status: '出品停止', 
+      delivery_fee: '300', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '大阪府',
+      shipping_date: '20191009',
+      user_id: '3', 
+      brand_id: '15', 
+      category_id: '9', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'AJIDESUTシャツ', 
+      price: '1500', 
+      usage_status: '新品', 
+      description: 'アジなTシャツ',
+      selling_status: '出品中', 
+      delivery_fee: '300', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '大阪府',
+      shipping_date: '20191009',
+      user_id: '3', 
+      brand_id: '15', 
+      category_id: '9', 
+      payment_status: '支払済'
+    },
+
+
+  ]
+)
+  
+
+# ハンドメイド
+Item.create!(
+  [
+    {
+      name: 'ハンドメイドキーホルダーおじさん', 
+      price: '550', 
+      usage_status: '中古', 
+      description: '手作りのおじさん',
+      selling_status: '出品停止', 
+      delivery_fee: '300', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '奈良県',
+      shipping_date: '20191001',
+      user_id: '1', 
+      brand_id: '17', 
+      category_id: '10', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'ハンドメイドJAPANグッズ', 
+      price: '15000', 
+      usage_status: '新品', 
+      description: 'これぞニッポン。メイドインジャパン',
+      selling_status: '売却済み', 
+      delivery_fee: '2000', 
+      delivery_way: 'Fmarket便',
+      delivery_area: '京都府',
+      shipping_date: '20190810',
+      user_id: '2', 
+      brand_id: '17', 
+      category_id: '10', 
+      payment_status: '未払い'
+    },
+  ]
+)
+
+# チケット
+Item.create!(
+  [
+    {
+      name: '関取トークショーチケット', 
+      price: '1800', 
+      usage_status: '新品', 
+      description: '相撲をみに行こう',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: '普通郵便',
+      delivery_area: '京都府',
+      shipping_date: '20190815',
+      user_id: '2', 
+      brand_id: '18', 
+      category_id: '11', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'ディズニーランドチケット', 
+      price: '5000', 
+      usage_status: '新品', 
+      description: '夢の国に行こう！',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: '普通郵便',
+      delivery_area: '京都府',
+      shipping_date: '20190815',
+      user_id: '2', 
+      brand_id: '22', 
+      category_id: '11', 
+      payment_status: '支払済'
+    },
+
+  ]
+)
+  
+# 自動車・オートバイ
+Item.create!(
+  [
+    {
+      name: '走行速度300km デススター', 
+      price: '3000000', 
+      usage_status: '中古', 
+      description: '惑星を一撃で吹き飛ばすほどの強い威力に要注意',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: '普通郵便',
+      delivery_area: '広島県',
+      shipping_date: '20190710',
+      user_id: '1', 
+      brand_id: '15', 
+      category_id: '12', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'ミレニアムファルコン', 
+      price: '5000000', 
+      usage_status: '中古', 
+      description: '初期シリーズ',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: '普通郵便',
+      delivery_area: '広島県',
+      shipping_date: '20190710',
+      user_id: '1', 
+      brand_id: '21', 
+      category_id: '12', 
+      payment_status: '支払済'
+    },
+    {
+      name: 'セール中！宇宙の仲間たち', 
+      price: '5000', 
+      usage_status: '中古', 
+      description: 'あの仲間たちが登場！',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: '普通郵便',
+      delivery_area: '広島県',
+      shipping_date: '20190710',
+      user_id: '1', 
+      brand_id: '21', 
+      category_id: '12', 
+      payment_status: '支払済'
+    },
+    {
+      name: '惑星間をひとっ飛び！未確認生命体', 
+      price: '200000', 
+      usage_status: '中古', 
+      description: '惑星間ドライブはいかが',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: '普通郵便',
+      delivery_area: '広島県',
+      shipping_date: '20190710',
+      user_id: '1', 
+      brand_id: '15', 
+      category_id: '12', 
+      payment_status: '支払済'
+    },
+
+
+  ]
+)
+  
+
+
+# その他
+Item.create!(
+  [
+    {
+      name: 'スペイン産オレンジハニー', 
+      price: '450', 
+      usage_status: '新品', 
+      description: '地中海のあまみ。',
+      selling_status: '売却済み', 
+      delivery_fee: '100', 
+      delivery_way: '普通郵便',
+      delivery_area: '広島県',
+      shipping_date: '20190710',
+      user_id: '1', 
+      brand_id: '23', 
+      category_id: '13', 
+      payment_status: '支払済'
+    },
+  ]
+)
+
+
+Image.create!(
+  [
+    {
+      # シャネルセール品３点
+      image: 'https://image.interior-book.jp/article/original/56619.jpg',
+      item_id: '1',
+    },
+    {
+      # カビゴン着ぐるみ
+      image: 'https://shop.r10s.jp/wigland/cabinet/110717/szj18-tmy-061.jpg',
+      item_id: '2',
+    },
+    {
+      # グッチTシャツ
+      image: 'https://i.pinimg.com/736x/06/58/e4/0658e4e5b54e2f5768c9dc2e9ca08487.jpg',
+      item_id: '3',
+    },
+
+    {
+      # 黄金に輝く胸筋
+      image: 'https://monde.jp/blog/wp-content/uploads/2018/09/toop-5.jpg',
+      item_id: '4',
+    },
+    {
+      # ブラウンニット
+      image: 'https://www.wearstand.com/upload/save_image/ps_5166405_505_m.jpg',
+      item_id: '5',
+    },
+    {
+      # イケてるトレンチコート
+      image: 'https://im.uniqlo.com/images/jp/pc/goods/419981/item/32_419981.jpg',
+      item_id: '6',
+    },
+
+
+    {
+      # ボスベイビー
+      image: 'https://bossbaby.jp/news/wp-content/uploads/sites/42/2018/04/bb_cg_Boss_Baby_05_RGB-%E3%82%B3%E3%83%94%E3%83%BC.jpg',
+      item_id: '7',
+    },
+
+    {
+      # ギフトにもGoodよだれかけ
+      image: 'https://marlmarl-cdn.azureedge.net/pub/assets/img/model/macaron/macaron-3_mauve/macaron-3_mauve-m1.jpg',
+      item_id: '8',
+    },
+
+
+    {
+      # 流れるアンモナイト型シンク
+      image: 'http://livedoor.blogimg.jp/hamusoku/imgs/f/0/f014ad2e.jpg',
+      item_id: '9',
+    },
+    {
+      # アップルメモパッド
+      image: 'http://www.neverlandclub.jp/images/e2/e2688/image.jpg',
+      item_id: '10',
+    },
+    
+    {
+      # 安心引きこもりライフ
+      image: 'https://up.gc-img.net/post_img_web/2014/05/InEKjVpSmGvrmFE',
+      item_id: '11',
+    },
+    {
+      # マッチョでぽん
+      image: 'http://blog-imgs-95.fc2.com/h/i/t/hitoikigame/macho_main.jpg',
+      item_id: '12',
+    },
+    {
+      # ゲームキューブカセット
+      image: 'https://image.biccamera.com/img/00000001994940_A01.jpg?sr.dw=320&sr.dh=320&sr.jqh=60&sr.mat=1',
+      item_id: '13',
+    },
+
+    {
+      # ゲロゲロ卵の黄身
+      image: 'https://img2.bgxcdn.com/thumb/view/oaupload/banggood/images/73/4A/53a93389-1091-2feb-c03b-d3909ecc7ca6.jpg',
+      item_id: '14',
+    },
+    {
+      # フリーザのような美肌に！ドラゴンボールフェイスパック
+      image: 'https://shop35-makeshop.akamaized.net/shopimages/isshindo/000000000051.jpg',
+      item_id: '15',
+    },
+
+    {
+      # クロエ香水
+      image: 'http://www.happiness-d.com/img/goods/L/kuroeo-doparufamu%20EPS75ml_l.jpg',
+      item_id: '16',
+    },
+
+
+    {
+      # ピザ機
+      image: 'http://ure.pia.co.jp/mwimgs/9/3/-/img_93cf494da83a05a87813ebc9bbf2100157735.jpg',
+      item_id: '17',
+    },
+    {
+      # おしるこプロテイン
+      image: 'https://cdn-ak.f.st-hatena.com/images/fotolife/s/ssachiko/20180120/20180120185647.jpg',
+      item_id: '18',
+    },
+    {
+      # バタフライラケット
+      image: 'https://tshop.r10s.jp/arhua/cabinet/2016/04c/16720_1.jpg?fitin=300:300',
+      item_id: '19',
+    },
+    {
+      # ajidesuシャツ
+      image: ' https://auctions.afimg.jp/item_data/image/20110324/yahoo/b/b119144780.1.jpg',
+      item_id: '20',
+    },
+
+    {
+      # おじさんキーホルダー
+      image: 'https://media-01.creema.net/user/1543965/exhibits/3315665/0_18ef12f2ff05ba2cb05eac25c91d52a7_583x585.jpg',
+      item_id: '21',
+    },
+    {
+      # ジャパングッズ
+      image: 'https://s3-ap-northeast-1.amazonaws.com/hmj-fes-production/users/creation_1s/000/012/671/original/d00042d2-1784-44c3-a7c2-63cbe81527c120181213-4-4nvbdn.jpg?1544686864',
+      item_id: '22',
+    },
+    {
+      # 関取トークショー
+      image: 'https://s3-ap-northeast-1.amazonaws.com/welltool/officials/offi290/spaces/spce288/arti3944_1_1570123069.jpg',
+      item_id: '23',
+    },
+    {
+      # ディズニーチケット
+      image: 'https://c05.castel.jp/picture?url=https%3A%2F%2Fcastel.jp%2Fimg%2Fup%2Fpicture_39386.jpg',
+      item_id: '24',
+    },
+
+
+    {
+      # 走行速度300km デススター
+      image: 'https://wired.jp/wp-content/uploads/2012/12/death-star-660x448.jpg',
+      item_id: '25',
+    },
+    {
+      # ミレニアムファルコン
+      image: 'https://cache.ymall.jp/webcom/item/multiimage/300/7657888012_001.jpg',
+      item_id: '26',
+    },
+    {
+      # セール中！宇宙の仲間たち
+      image: 'https://shop.daigo.co.jp/wp-content/uploads/post/26858/S3709.jpg',
+      item_id: '27',
+    },
+    {
+      # 惑星間をひとっ飛び未確認生命体
+      image: 'https://img.sirabee.com/wp-content/uploads/2019/09/GettyImages-1054137738.jpg',
+      item_id: '28',
+    },
+    
+    {
+      # スパイン産オレンジハニー
+      image: 'http://www.tullys.co.jp/menu/uploads/orangehoney_191015.jpg',
+      item_id: '29',
+    },
+
+  ]
+)
+
+# Likeテーブル
+
+Like.create!(
+  [
+    {
+      user_id: '1', 
+      item_id: '4', 
+    },
+    {
+      user_id: '1', 
+      item_id: '11', 
+    },
+    {
+      user_id: '1', 
+      item_id: '12', 
+    },
+    {
+      user_id: '1', 
+      item_id: '23', 
+    },
+
+  ]
+)


### PR DESCRIPTION
## What
・トップページ一覧で商品（Item）をDBから表示させる。
　→いいね！した商品（いいね機能はこれから実装なので一旦はランダム表示）
　→人気のカテゴリー・ブランドのタイトルリスト表示（カテゴリーは親カテゴリーのみancestry=nullで指定して選択）
　→カテゴリー・ブランドの新着アイテム
　　→タイトルのカテゴリー/ブランドidに紐づいたItem, Imageデータを表示

・Seedファイル作成
　→ダミーデータ用に、User(３)、Item・Image（26）・Brand（23）データ作成

・px→remに修正

・崩れたビューの修正（ヘッダー・フッター・ログインボタンなど）

![スクリーンショット 2019-11-25 19 52 32](https://user-images.githubusercontent.com/56525170/69534525-58b95d00-0fbd-11ea-8392-f7b7957d5334.png)
![スクリーンショット 2019-11-25 19 52 49](https://user-images.githubusercontent.com/56525170/69534533-5d7e1100-0fbd-11ea-86ee-4812983b7bfb.png)
![スクリーンショット 2019-11-25 19 53 06](https://user-images.githubusercontent.com/56525170/69534549-62db5b80-0fbd-11ea-8443-5f220c7f9def.png)
![スクリーンショット 2019-11-25 19 53 16](https://user-images.githubusercontent.com/56525170/69534562-6969d300-0fbd-11ea-8a86-7e6ea5d51388.png)




## Changed files to check
[レビュー確認ファイル]
・home.scss
・index.html.haml
・homes.controller.rb
・seeds.rb

　　