### PR TITLE
【マークアップ】売却済みのアイテムにはSOLDが出るように変更

### DIFF
--- a/app/assets/stylesheets/homes/home.scss
+++ b/app/assets/stylesheets/homes/home.scss
@@ -164,14 +164,14 @@ button.search-logo {
 
 .main-toppage {
   width: 75%;
+  margin: auto;
 
   .MainMenu {
     &__FavoriteItems {
-      height: 28rem;
+      height: 30rem;
       background-color: #ffbf1f;
       width: 100%;
-      margin-left: 15.3rem;
-      margin-top: 3rem;
+      margin: auto;
 
       &__Header {
         height: 5rem;
@@ -180,16 +180,48 @@ button.search-logo {
         margin: 0;
         display: flex;
         justify-content: space-between;
-        padding: 1rem;
+        padding: 2rem 0 1rem 3rem;
       }
 
       &__Body {
+        height: calc(100% - 5rem);
         &__Items {
           &__All {
             &__List {
-              padding: 3rem;
+              margin-left: 3rem;
+              &__images {
+                display: flex;
+                &__image {
+                  margin-right: 3rem;
+                  border: 0.1rem solid #dddddd;
+                  position: relative;
 
-              &__image {
+                  .favorite-item-image {
+                    display: block;
+                    height: 20rem;
+                    width: 18rem;
+                  }
+                  .home__sold-out-image {
+                    border: 3rem solid;
+                    width: 0;
+                    height: 0;
+                    border-style: solid;
+                    border-color: $red transparent transparent $red;
+                    z-index: 1;
+                    position: absolute;
+                  }
+                  .home__sold-out-text {
+                    font-size: 1.5rem;
+
+                    color: #fff;
+                    font-weight: bolder;
+                    letter-spacing: 0.1em;
+                    position: absolute;
+                    top: -1.7rem;
+                    left: -3rem;
+                    transform: rotateZ(315deg);
+                  }
+                }
               }
             }
           }
@@ -201,13 +233,13 @@ button.search-logo {
       height: 17.1rem;
       width: 100%;
       background-color: rgb(255, 255, 255);
-      margin-left: 15.3rem;
 
       &__List {
         &__All {
           width: 75%;
-          margin-left: 13.5rem;
-
+          margin: auto;
+          display: flex;
+          justify-content: center;
           &__list {
             display: inline-block;
             font-size: 1.4rem;
@@ -227,7 +259,7 @@ button.search-logo {
       height: 40rem;
       background-color: #000000;
       width: 100%;
-      margin-left: 15.3rem;
+
       margin-bottom: 10rem;
 
       &__Header {
@@ -250,6 +282,34 @@ button.search-logo {
             &__List {
               padding: 1rem, 1.6rem, 0, 1.6rem;
               display: flex;
+              &__item {
+                margin-left: 1rem;
+                .body-item-image {
+                  display: flex;
+                  height: 23rem;
+                  width: 20rem;
+                  border-style: groove;
+                  background-size: cover;
+                }
+                .home__sold-out-image {
+                  border: 3rem solid;
+                  width: 0;
+                  height: 0;
+                  border-style: solid;
+                  border-color: $red transparent transparent $red;
+                  z-index: 1;
+                  position: absolute;
+                }
+                .home__sold-out-text {
+                  font-size: 1.5rem;
+                  color: #fff;
+                  font-weight: bolder;
+                  position: absolute;
+                  top: -1.7rem;
+                  left: -3rem;
+                  transform: rotateZ(315deg);
+                }
+              }
             }
           }
         }
@@ -265,12 +325,13 @@ button.search-logo {
       height: 17.1rem;
       width: 100%;
       background-color: rgb(255, 255, 255);
-      margin-left: 15.3rem;
 
       &__List {
         &__All {
           width: 75%;
-          margin-left: 11.5rem;
+          margin: auto;
+          display: flex;
+          justify-content: center;
 
           &__list {
             display: inline-block;
@@ -278,7 +339,7 @@ button.search-logo {
             height: 3.2rem;
 
             padding: 1rem;
-            margin: 4rem 5rem 0 5rem;
+            margin: 4rem 2rem 0 2rem;
 
             background-color: #dddddd;
             border-radius: 2rem;
@@ -291,7 +352,7 @@ button.search-logo {
       height: 40rem;
       background-color: #000000;
       width: 100%;
-      margin-left: 15.3rem;
+
       margin-bottom: 5rem;
 
       &__Header {
@@ -335,31 +396,12 @@ p.show-detail {
 figcaption {
   height: 5rem;
   width: 20rem;
-  margin: 0.1rem 1rem 1rem 1rem;
+  margin-top: 0.1rem;
   position: absolute;
   background-color: grey;
   color: #dddddd;
   text-align: center;
   line-height: initial;
-}
-
-.body-item-image {
-  display: flex;
-  height: 23rem;
-  width: 20rem;
-  border-style: groove;
-  background-size: cover;
-  margin: 1rem;
-}
-
-.favorite-item-image {
-  display: block;
-  height: 15rem;
-  width: 18rem;
-  border-style: outset;
-  float: left;
-  background-size: cover;
-  margin: 1rem;
 }
 
 h2.category-title {

--- a/app/assets/stylesheets/items/show.scss
+++ b/app/assets/stylesheets/items/show.scss
@@ -16,6 +16,27 @@
       background-color: #fafafa;
       .item-detail-phone-big {
         line-height: 0;
+        position: relative;
+
+        .item-detail__show__sold-out-image {
+          border: 5rem solid;
+          width: 0;
+          height: 0;
+          border-style: solid;
+          border-color: $red transparent transparent $red;
+          z-index: 1;
+          position: absolute;
+        }
+        .item-detail__show__sold-out-text {
+          font-size: 2rem;
+          letter-spacing: 0.1em;
+          color: #fff;
+          font-weight: bolder;
+          position: absolute;
+          top: -2rem;
+          left: -5rem;
+          transform: rotateZ(315deg);
+        }
         .item-detail-phone-big-main {
           height: 30rem;
           width: 30rem;
@@ -71,7 +92,7 @@
             font-weight: 900;
             display: inline-block;
             margin-left: 1.6rem;
-            color: #FFCC66;
+            color: #ffcc66;
           }
           .bad-icon::before {
             font-family: "Font Awesome 5 Free";
@@ -79,7 +100,7 @@
             font-weight: 900;
             display: inline-block;
             margin-left: 1.6rem;
-            color: #5D99FF;
+            color: #5d99ff;
           }
         }
         .category-icon {
@@ -96,7 +117,9 @@
     .item-price-box__price {
       margin-right: 1.6rem;
       font-size: 5rem;
-      font-family: 'Avenir','Helvetica Neue','Helvetica','Arial','Hiragino Sans','ヒラギノ角ゴシック',YuGothic,'Yu Gothic','メイリオ', Meiryo,'ＭＳ Ｐゴシック','MS PGothic';
+      font-family: "Avenir", "Helvetica Neue", "Helvetica", "Arial",
+        "Hiragino Sans", "ヒラギノ角ゴシック", YuGothic, "Yu Gothic", "メイリオ",
+        Meiryo, "ＭＳ Ｐゴシック", "MS PGothic";
     }
     .item-price-box__tax {
       font-size: 1rem;

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -18,11 +18,13 @@
                         .MainMenu__FavoriteItems__Body__Items
                             .MainMenu__FavoriteItems__Body__Items__All
                                 .MainMenu__FavoriteItems__Body__Items__All__List
-                                    .MainMenu__FavoriteItems__Body__Items__All__List__image
+                                    .MainMenu__FavoriteItems__Body__Items__All__List__images
                                         - @like_rankings.each do |image|
-                                            = link_to item_path(image.item.id) do
-                                                = image_tag image.image , height: '150', width: '180', class:'favorite-item-image'
-
+                                            = link_to item_path(image.item.id), class: "MainMenu__FavoriteItems__Body__Items__All__List__images__image" do
+                                                - if image.item.selling_status == "売却済み"
+                                                    .home__sold-out-image
+                                                        %span.home__sold-out-text SOLD
+                                                = image_tag image.image, class:'favorite-item-image'
             - if @items.any?
                 .MainMenu__CategoryLists
                     %h2.category-title 人気のカテゴリー
@@ -48,9 +50,12 @@
                                         - @items.each do |item|
                                             - if item.category.root_id == category.id
                                                 - itemscounts += 1
-                                                %figure
+                                                %figure.MainMenu__CategoryItems__Body__Items__All__List__item
                                                     = link_to item_path(item.id) do
-                                                        = image_tag item.images.first.image , height: '230', width: '200', class:'body-item-image'
+                                                        - if item.selling_status == "売却済み"
+                                                            .home__sold-out-image
+                                                                %span.home__sold-out-text SOLD
+                                                        = image_tag item.images.first.image , class:'body-item-image'
                                                         %figcaption
                                                             = item.name
                                                 - break if itemscounts == 5
@@ -83,12 +88,15 @@
                                         - @items.each do |item|
                                             - if item.brand_id == brand.id
                                                 - itemscounts += 1
-                                                %figure
+                                                %figure.MainMenu__CategoryItems__Body__Items__All__List__item
                                                     = link_to item_path(item.id) do
-                                                        = image_tag item.images.first.image , height: '230', width: '200', class:'body-item-image'
+                                                        - if item.selling_status == "売却済み"
+                                                            .home__sold-out-image
+                                                                %span.home__sold-out-text SOLD
+                                                        = image_tag item.images.first.image , class:'body-item-image'
                                                         %figcaption
                                                             = item.name
-                                            - break if itemscounts == 5
+                                                - break if itemscounts == 5
 
 
     %aside.aside-toppage

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,6 +8,9 @@
     .item-detail-content__information--pictures
       .item-detail-phone-big
         - @item.images.first(1).each do |image|
+          - if @item.selling_status == "売却済み"
+            .item-detail__show__sold-out-image
+              %span.item-detail__show__sold-out-text SOLD
           = image_tag image.image, class: "item-detail-phone-big-main"
       .item-detail-phone-cells
         - @item.images.each do |image|


### PR DESCRIPTION
## what
アイテム一覧とアイテム詳細でselling-statusが売却済みの場合はアイテムの写真エリアにsoldが出るように変更

## why
ユーザが購入可能な商品かどうかをわかりやすくするため

## 自作
<img width="213" alt="スクリーンショット 2019-11-29 16 31 03" src="https://user-images.githubusercontent.com/54981611/69852689-45add200-12c8-11ea-9183-b67a48e3018f.png">

## 本家
<img width="217" alt="スクリーンショット 2019-11-29 16 31 23" src="https://user-images.githubusercontent.com/54981611/69852690-45add200-12c8-11ea-835b-67411c2d41ba.png">

## 自作
<img width="317" alt="スクリーンショット 2019-11-29 17 04 46" src="https://user-images.githubusercontent.com/54981611/69854188-ccb07980-12cb-11ea-9274-755d3fcfd444.png">


## 本家
<img width="322" alt="スクリーンショット 2019-11-29 16 31 48" src="https://user-images.githubusercontent.com/54981611/69852692-46deff00-12c8-11ea-89e1-1f1821485311.png">



