### PR TITLE
売却済みの商品詳細ページから購入ページに行けないように変更

### DIFF
--- a/app/assets/stylesheets/items/show.scss
+++ b/app/assets/stylesheets/items/show.scss
@@ -139,6 +139,15 @@
       line-height: 6rem;
       font-weight: 600;
     }
+    &__sold {
+      height: 5.5rem;
+      width: 58rem;
+      background-color: #888;
+      color: #fff;
+      font-size: 2.4rem;
+      line-height: 6rem;
+      font-weight: 600;
+    }
   }
   .item-description {
     padding: 3.2rem 0 0;
@@ -154,7 +163,7 @@
         background-color: #f5f5f5;
         color: #333;
         display: inline-block;
-        }
+      }
       .item-report-btn {
         padding: 0.8rem 1.6rem;
         border-radius: 4rem;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -69,12 +69,16 @@
 
   .item-price-box
     %span.item-price-box__price
-      = "¥#{@item.price}"
+      = "¥#{@item.price.to_s(:delimited)}"
     %span.item-price-box__tax (税込)
     %span.item-price-box__postage 着払い
 
   .item-buy-btn
-    = button_to "購入画面に進む", buy_order_path(@item.id),method: :get, class: "btn-default item-buy-btn__red"
+    - if @item.selling_status == "売却済み" #active_hash導入後に変更が必要
+      .btn-default.item-buy-btn__sold
+        売り切れました
+    - else
+      = button_to "購入画面に進む", buy_order_path(@item.id),method: :get, class: "btn-default item-buy-btn__red"
   .item-description
     %p
       = @item.description

--- a/app/views/mypages/exhibit_item.html.haml
+++ b/app/views/mypages/exhibit_item.html.haml
@@ -59,7 +59,7 @@
 
   .item-price-box
     %span.item-price-box__price
-      = "¥#{@item.price}"
+      = "¥#{@item.price.to_s(:delimited)}"
     %span.item-price-box__tax (税込)
     %span.item-price-box__postage 着払い
 

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -15,7 +15,7 @@
         .buy-panel__item-detail-inner
           .buy-panel__item-detail-inner__box
             %p.buy-panel__item-detail-inner__box__price
-              ="¥#{@item.price}"
+              ="¥#{@item.price.to_s(:delimited)}"
             %p.buy-panel__item-detail-inner__box__delivery_fee
               送料込み
 
@@ -28,7 +28,7 @@
             %p.buy-panel__item-detail-inner__pay__message
               支払い金額
             %p.buy-panel__item-detail-inner__pay__price
-              ="¥#{@item.price}"
+              ="¥#{@item.price.to_s(:delimited)}"
         - unless @user.address.present? && @user.creditcard.present?
           %p.buy-panel__item-detail-inner__error
             配送先と支払い方法の入力を完了してください
@@ -48,7 +48,7 @@
             %p.buy-panel__item-detail-inner__buyer
               ="#{@user.lastname} #{@user.firstname}"
             .buy-panel__item-detail-inner__link
-              = link_to "/mypage/address", class: "go-to_change" do  
+              = link_to "/mypage/address", class: "go-to_change" do
                 %span.go-to_change__messaege 変更する
                 %i.fas.fa-angle-right
 
@@ -64,6 +64,6 @@
             = link_to "/mypage/card", class: "go-to_change" do
               %span.go-to_change__messaege 変更する
               %i.fas.fa-angle-right
-            
+
     .single-footer
       = render 'signups/footer'


### PR DESCRIPTION
## what
selling_statusの値によってviewを変更する
→売却済みの場合購入ページに行けない
数値にカンマ区切りを追加

## why
ユーザが売却済みの商品を変えないようにするために

## 本家
<img width="709" alt="スクリーンショット 2019-12-02 12 49 20" src="https://user-images.githubusercontent.com/54981611/69929704-526a3a00-1503-11ea-8811-08f0e53ade88.png">

## 自作
<img width="724" alt="スクリーンショット 2019-12-02 12 49 07" src="https://user-images.githubusercontent.com/54981611/69929713-60b85600-1503-11ea-8d60-69740c54b478.png">


<img width="713" alt="スクリーンショット 2019-12-02 13 23 32" src="https://user-images.githubusercontent.com/54981611/69930557-3cf70f00-1507-11ea-8ba7-14b5c1aba4dd.png">
<img width="723" alt="スクリーンショット 2019-12-02 13 24 31" src="https://user-images.githubusercontent.com/54981611/69930558-3cf70f00-1507-11ea-9412-9470e54ff469.png">
